### PR TITLE
Add BlockCreator to SignBreakAlerts and fix outdated worldedit repo.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 
 archivesBaseName = 'griefalert' // Project Base Name Here
 group = 'com.minecraftonline.sponge' // This is a MinecraftOnline project
-version = '1.4.0' // Project Version
+version = '1.4.1' // Project Version
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ publishing {
 repositories {
 	mavenCentral()
     google()
-    maven { url "http://maven.sk89q.com/repo/" }
+    maven { url "https://maven.enginehub.org/repo/" }
     maven { url "https://jitpack.io" }
     jcenter()
     flatDir {

--- a/src/main/java/com/minecraftonline/griefalert/alerts/prism/SignBreakAlert.java
+++ b/src/main/java/com/minecraftonline/griefalert/alerts/prism/SignBreakAlert.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 /**
  * An alert caused by breaking a sign.
  */
-public class SignBreakAlert extends PrismAlert {
+public class SignBreakAlert extends BreakAlert {
 
   /**
    * Default constructor for a sign break alert. This add all the 'extra'


### PR DESCRIPTION
- Made SignBreakAlert extend BreakAlert, so it gains the block creator and any future changes.
- Changed the sk89q maven repo to the newer enginehub repo that works (and use https).